### PR TITLE
Added support for an "os" tag in index.yaml.

### DIFF
--- a/source/lib/Seco/Multipkg.pm
+++ b/source/lib/Seco/Multipkg.pm
@@ -179,6 +179,8 @@ sub setrelease {
   # build from source checkout
   $self->info->data->{release} = sprintf "0.%u", time()
     unless ( defined $self->info->data->{release} );
+  $self->info->data->{release} .= "." . $self->info->data->{os}
+    if (defined($self->info->data->{os}));
 }
 
 sub pkgverid {


### PR DESCRIPTION
If supplied, it will be appended to the "release" tag. This allows you do generate RPMS with names that look like this:
lxc-square-1.0-1453753102.el7.noarch.rpm
